### PR TITLE
Features/stopwatch

### DIFF
--- a/PhaseShift.AccuracyTestTool/PhaseShift.AccuracyTestTool.csproj
+++ b/PhaseShift.AccuracyTestTool/PhaseShift.AccuracyTestTool.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PhaseShift.Core\PhaseShift.Core.csproj" />
+    <ProjectReference Include="..\PhaseShift.UI.Tests\PhaseShift.UI.Tests.csproj" />
+    <ProjectReference Include="..\PhaseShift.UI\PhaseShift.UI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PhaseShift.AccuracyTestTool/Program.cs
+++ b/PhaseShift.AccuracyTestTool/Program.cs
@@ -1,14 +1,12 @@
-﻿
-using PhaseShift.Core.AccuracyTestTool.Tests;
-using PhaseShift.UI.StopwatchFeature;
+﻿using PhaseShift.AccuracyTestTool.Tests;
 
-namespace PhaseShift.Core.AccuracyTestTool;
+namespace PhaseShift.AccuracyTestTool;
 
 internal class Program
 {
     private const int AcceptableDeviationMilliseconds = 10;
     private const int ExpectedElapsedTimeMilliseconds = 10_000;
-    private const int SampleCount = 10;
+    private const int SampleCount = 100;
 
     static void Main(string[] args)
     {
@@ -33,6 +31,9 @@ internal class Program
         }
 
         PrintSummary(tests);
+
+        Console.WriteLine("\nPress any key to exit...");
+        Console.ReadKey();
     }
 
     private static void PrintSummary(List<AccuracyTest> tests)

--- a/PhaseShift.AccuracyTestTool/Program.cs
+++ b/PhaseShift.AccuracyTestTool/Program.cs
@@ -1,0 +1,56 @@
+﻿
+using PhaseShift.Core.AccuracyTestTool.Tests;
+using PhaseShift.UI.StopwatchFeature;
+
+namespace PhaseShift.Core.AccuracyTestTool;
+
+internal class Program
+{
+    private const int AcceptableDeviationMilliseconds = 10;
+    private const int ExpectedElapsedTimeMilliseconds = 10_000;
+    private const int SampleCount = 10;
+
+    static void Main(string[] args)
+    {
+        var options = new AccuracyTest.Options()
+        {
+            SampleCount = SampleCount,
+            AcceptableDeviationMilliseconds = AcceptableDeviationMilliseconds,
+            ExpectedElapsedTimeMilliseconds = ExpectedElapsedTimeMilliseconds
+        };
+
+        var tests = new List<AccuracyTest>
+        {
+            new AsyncStopwatchTest(options),
+            new StopwatchVmTest(options),
+        };
+
+        foreach (var test in tests)
+        {
+            Console.WriteLine($"Starting {test.Title} accuracy test...\n");
+            test.Execute();
+            Console.WriteLine();
+        }
+
+        PrintSummary(tests);
+    }
+
+    private static void PrintSummary(List<AccuracyTest> tests)
+    {
+        Console.WriteLine("Test Summary:\n");
+        foreach (var test in tests)
+        {
+            if (test.IsSuccess)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine($"{test.Title} Test: Succeeded");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"{test.Title} Test: Failed");
+            }
+            Console.ResetColor();
+        }
+    }
+}

--- a/PhaseShift.AccuracyTestTool/Tests/AccuracyTest.cs
+++ b/PhaseShift.AccuracyTestTool/Tests/AccuracyTest.cs
@@ -1,0 +1,76 @@
+﻿namespace PhaseShift.Core.AccuracyTestTool.Tests;
+
+internal abstract class AccuracyTest
+{
+    protected readonly int _expectedElapsedTimeMilliseconds;
+    private const int SecondsInAnHour = 3_600;
+
+    private readonly int _acceptableDeviationMilliseconds;
+    private readonly int _sampleCount;
+    private readonly StatisticalTest _test;
+
+    protected AccuracyTest(Options options)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.SampleCount, 1, nameof(options.SampleCount));
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.AcceptableDeviationMilliseconds, 1, nameof(options.AcceptableDeviationMilliseconds));
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.ExpectedElapsedTimeMilliseconds, 1, nameof(options.ExpectedElapsedTimeMilliseconds));
+
+        _sampleCount = options.SampleCount;
+        _acceptableDeviationMilliseconds = options.AcceptableDeviationMilliseconds;
+        _expectedElapsedTimeMilliseconds = options.ExpectedElapsedTimeMilliseconds;
+
+        _test = new StatisticalTest(MeasureElapsedTime, _sampleCount);
+        _test.SampleGenerated += (_, totalSamples) =>
+        {
+            Console.WriteLine($"Generated sample {totalSamples} of {_sampleCount} ({totalSamples / (double)_sampleCount:P2})");
+        };
+    }
+
+    public double DeviationMilliseconds => _test.SampleMean - _expectedElapsedTimeMilliseconds;
+    public bool IsSuccess => Math.Abs(DeviationMilliseconds) < _acceptableDeviationMilliseconds;
+    public abstract string Title { get; }
+    public void Execute()
+    {
+        _test.Execute();
+        PrintTestSummary();
+    }
+
+    protected abstract double MeasureElapsedTime();
+
+    private void PrintTestSummary()
+    {
+        Console.WriteLine($"\nMean: {_test.SampleMean:F2} ms");
+        Console.WriteLine($"Standard deviation: {_test.SampleStandardDeviation:F2} ms ({_test.RelativeSampleStandardDeviation:P2})");
+        Console.WriteLine();
+
+        var acceptableDeviationSecondsPerHour = _acceptableDeviationMilliseconds / _expectedElapsedTimeMilliseconds * SecondsInAnHour;
+        Console.WriteLine($"Acceptable deviation: {_acceptableDeviationMilliseconds:F2} ms ({acceptableDeviationSecondsPerHour:F2} s per hour)");
+        Console.WriteLine($"Expected elapsed time: {_expectedElapsedTimeMilliseconds:F2} ms");
+        Console.WriteLine();
+
+        var actualDeviationSecondsPerHour = DeviationMilliseconds / _expectedElapsedTimeMilliseconds * SecondsInAnHour;
+        var relativeDeviation = DeviationMilliseconds / _expectedElapsedTimeMilliseconds;
+
+        Console.WriteLine($"Actual deviation: {DeviationMilliseconds:F2} ms ({relativeDeviation:P2}, {actualDeviationSecondsPerHour:F2} s per hour)");
+
+        if (IsSuccess)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("Test passed!");
+            Console.ResetColor();
+        }
+        else
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("Test failed!");
+            Console.ResetColor();
+        }
+    }
+
+    public struct Options()
+    {
+        public int AcceptableDeviationMilliseconds { get; set; } = 1;
+        public int ExpectedElapsedTimeMilliseconds { get; set; } = 1000;
+        public int SampleCount { get; set; } = 10;
+    }
+}

--- a/PhaseShift.AccuracyTestTool/Tests/AsyncStopwatchTest.cs
+++ b/PhaseShift.AccuracyTestTool/Tests/AsyncStopwatchTest.cs
@@ -1,9 +1,9 @@
-﻿namespace PhaseShift.Core.AccuracyTestTool.Tests;
+﻿using PhaseShift.Core;
 
-internal class AsyncStopwatchTest(AccuracyTest.Options options) : AccuracyTest(options)
+namespace PhaseShift.AccuracyTestTool.Tests;
+
+internal class AsyncStopwatchTest(AccuracyTest.Options options, string? title = null) : AccuracyTest(options, title)
 {
-    public override string Title => typeof(AsyncStopwatch).ToString();
-
     protected override double MeasureElapsedTime()
     {
         var asyncStopwatch = new AsyncStopwatch(_ => { }, 10);

--- a/PhaseShift.AccuracyTestTool/Tests/AsyncStopwatchTest.cs
+++ b/PhaseShift.AccuracyTestTool/Tests/AsyncStopwatchTest.cs
@@ -1,0 +1,16 @@
+﻿namespace PhaseShift.Core.AccuracyTestTool.Tests;
+
+internal class AsyncStopwatchTest(AccuracyTest.Options options) : AccuracyTest(options)
+{
+    public override string Title => typeof(AsyncStopwatch).ToString();
+
+    protected override double MeasureElapsedTime()
+    {
+        var asyncStopwatch = new AsyncStopwatch(_ => { }, 10);
+        asyncStopwatch.Start();
+        Thread.Sleep(_expectedElapsedTimeMilliseconds);
+        asyncStopwatch.Stop();
+
+        return asyncStopwatch.ElapsedTime.TotalMilliseconds;
+    }
+}

--- a/PhaseShift.AccuracyTestTool/Tests/StatisticalTest.cs
+++ b/PhaseShift.AccuracyTestTool/Tests/StatisticalTest.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Concurrent;
+
+namespace PhaseShift.Core.AccuracyTestTool.Tests;
+
+/// <summary>
+/// Represents a statistical test that performs multiple runs of a test candidate function,
+/// collects samples, and calculates statistical metrics such as the mean and standard deviation of the means.
+/// </summary>
+public class StatisticalTest
+{
+    private readonly ConcurrentBag<double> _samples = [];
+
+    private readonly int _sampleCount;
+    private readonly Func<double> _testCandidate;
+
+    private int _totalSamples;
+
+    /// <param name="testCandidate">The function to be tested.</param>
+    /// <param name="numberOfRuns">The number of runs to execute the test.</param>
+    /// <param name="sampleCount">The number of samples to collect per run.</param>
+    public StatisticalTest(Func<double> testCandidate, int sampleCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(sampleCount, 1, nameof(sampleCount));
+
+        _sampleCount = sampleCount;
+        _testCandidate = testCandidate;
+    }
+
+    public event EventHandler<int>? SampleGenerated;
+
+    public double SampleMean => _samples.Average();
+    public double SampleStandardDeviation => Math.Sqrt(_samples.Average(x => Math.Pow(x - SampleMean, 2)));
+    public double RelativeSampleStandardDeviation => SampleMean != 0 ? SampleStandardDeviation / SampleMean : double.NaN;
+
+    public void Execute()
+    {
+        Reset();
+
+        for (int i = 0; i < _sampleCount; i++)
+        {
+            _samples.Add(_testCandidate());
+            SampleGenerated?.Invoke(this, ++_totalSamples);
+        }
+    }
+
+    /// <summary>
+    /// Resets the collected data and measurement count.
+    /// </summary>
+    private void Reset()
+    {
+        _samples.Clear();
+        _totalSamples = 0;
+    }
+}

--- a/PhaseShift.AccuracyTestTool/Tests/StopwatchVmTest.cs
+++ b/PhaseShift.AccuracyTestTool/Tests/StopwatchVmTest.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+
+using PhaseShift.UI.Common;
+using PhaseShift.UI.StopwatchFeature;
+using PhaseShift.UI.Tests.Mocks;
+
+namespace PhaseShift.Core.AccuracyTestTool.Tests;
+
+internal class StopwatchVmTest(AccuracyTest.Options options) : AccuracyTest(options)
+{
+    public override string Title => typeof(StopwatchVm).ToString();
+
+    protected override double MeasureElapsedTime()
+    {
+        var mockDispatcher = new MockDispatcher();
+        var stopwatchVm = new StopwatchVm(mockDispatcher);
+        stopwatchVm.StartStopwatchCommand.Execute(null);
+        Thread.Sleep(_expectedElapsedTimeMilliseconds);
+        stopwatchVm.PauseStopwatchCommand.Execute(null);
+        Thread.Sleep(100); // Wait for elapsed time to update
+
+        return stopwatchVm.ElapsedTime.TotalMilliseconds;
+    }
+}

--- a/PhaseShift.AccuracyTestTool/Tests/StopwatchVmTest.cs
+++ b/PhaseShift.AccuracyTestTool/Tests/StopwatchVmTest.cs
@@ -1,20 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Threading;
-
-using PhaseShift.UI.Common;
-using PhaseShift.UI.StopwatchFeature;
+﻿using PhaseShift.UI.StopwatchFeature;
 using PhaseShift.UI.Tests.Mocks;
 
-namespace PhaseShift.Core.AccuracyTestTool.Tests;
+namespace PhaseShift.AccuracyTestTool.Tests;
 
-internal class StopwatchVmTest(AccuracyTest.Options options) : AccuracyTest(options)
+internal class StopwatchVmTest(AccuracyTest.Options options, string? title = null) : AccuracyTest(options, title)
 {
-    public override string Title => typeof(StopwatchVm).ToString();
-
     protected override double MeasureElapsedTime()
     {
         var mockDispatcher = new MockDispatcher();

--- a/PhaseShift.Core.Tests/AsyncStopwatchTests.cs
+++ b/PhaseShift.Core.Tests/AsyncStopwatchTests.cs
@@ -1,0 +1,111 @@
+﻿using NSubstitute;
+
+using NUnit.Framework;
+
+namespace PhaseShift.Core.Tests;
+
+[TestFixture]
+internal class AsyncStopwatchTests
+{
+    private Action<TimeSpan>? _tickHandler;
+    private AsyncStopwatch? _asyncStopwatch;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tickHandler = Substitute.For<Action<TimeSpan>>();
+        _asyncStopwatch = new AsyncStopwatch(_tickHandler);
+    }
+
+    [Test]
+    public async Task Start_ShouldInvokeAsyncTickHandler()
+    {
+        // Arrange
+        var elapsedTime = TimeSpan.Zero;
+        _tickHandler!.Invoke(Arg.Any<TimeSpan>());
+
+        // Act
+        _asyncStopwatch!.Start();
+        await Task.Delay(50); // Allow some time for the async handler to be invoked
+        _asyncStopwatch.Stop();
+
+        // Assert
+        _tickHandler.Received().Invoke(Arg.Any<TimeSpan>());
+    }
+
+    [Test]
+    public void Stop_ShouldStopTheStopwatch()
+    {
+        // Act
+        _asyncStopwatch!.Start();
+        _asyncStopwatch.Stop();
+
+        // Assert
+        Assert.That(_asyncStopwatch.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void Reset_ShouldResetElapsedTime()
+    {
+        // Act
+        _asyncStopwatch!.Start();
+        Task.Delay(50).Wait(); // Allow some time to pass
+        _asyncStopwatch.Reset();
+
+        // Assert
+        Assert.That(_asyncStopwatch.ElapsedTime, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void Reset_ShouldInvokeAsyncTickHandlerWithZeroElapsedTime()
+    {
+        // Arrange
+        _tickHandler!.Invoke(Arg.Any<TimeSpan>());
+
+        // Act
+        _asyncStopwatch!.Start();
+        Task.Delay(50).Wait(); // Allow some time to pass
+        _asyncStopwatch.Reset();
+
+        // Assert
+        _tickHandler.Received().Invoke(TimeSpan.Zero);
+    }
+
+    [Test]
+    public void IsRunning_ShouldBeTrueWhenStarted()
+    {
+        // Act
+        _asyncStopwatch!.Start();
+
+        // Assert
+        Assert.That(_asyncStopwatch.IsRunning, Is.True);
+    }
+
+    [Test]
+    public void IsRunning_ShouldBeFalseWhenStopped()
+    {
+        // Act
+        _asyncStopwatch!.Start();
+        _asyncStopwatch.Stop();
+
+        // Assert
+        Assert.That(_asyncStopwatch.IsRunning, Is.False);
+    }
+
+    [Test]
+    public async Task Stopwatch_ShouldHaveAcceptableAccuracy()
+    {
+        // Arrange
+        var acceptableDeviation = TimeSpan.FromMilliseconds(1000); // deviation <= 3.6 s per hour
+        var expectedElapsedTime = TimeSpan.FromMilliseconds(10_000);
+
+        // Act
+        _asyncStopwatch!.Start();
+        await Task.Delay(expectedElapsedTime);
+        _asyncStopwatch.Stop();
+        var actualElapsedTime = _asyncStopwatch.ElapsedTime;
+
+        // Assert
+        Assert.That(actualElapsedTime, Is.EqualTo(expectedElapsedTime).Within(acceptableDeviation));
+    }
+}

--- a/PhaseShift.Core.Tests/AsyncStopwatchTests.cs
+++ b/PhaseShift.Core.Tests/AsyncStopwatchTests.cs
@@ -91,21 +91,4 @@ internal class AsyncStopwatchTests
         // Assert
         Assert.That(_asyncStopwatch.IsRunning, Is.False);
     }
-
-    [Test]
-    public async Task Stopwatch_ShouldHaveAcceptableAccuracy()
-    {
-        // Arrange
-        var acceptableDeviation = TimeSpan.FromMilliseconds(1000); // deviation <= 3.6 s per hour
-        var expectedElapsedTime = TimeSpan.FromMilliseconds(10_000);
-
-        // Act
-        _asyncStopwatch!.Start();
-        await Task.Delay(expectedElapsedTime);
-        _asyncStopwatch.Stop();
-        var actualElapsedTime = _asyncStopwatch.ElapsedTime;
-
-        // Assert
-        Assert.That(actualElapsedTime, Is.EqualTo(expectedElapsedTime).Within(acceptableDeviation));
-    }
 }

--- a/PhaseShift.Core.Tests/PhaseShift.Core.Tests.csproj
+++ b/PhaseShift.Core.Tests/PhaseShift.Core.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PhaseShift.Core\PhaseShift.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/PhaseShift.Core/AsyncStopwatch.cs
+++ b/PhaseShift.Core/AsyncStopwatch.cs
@@ -40,6 +40,8 @@ public class AsyncStopwatch(Action<TimeSpan> tickHandler, int intervalMillisecon
             return;
         }
 
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
         _cancellationTokenSource = new CancellationTokenSource();
 
         IsRunning = true;
@@ -51,9 +53,8 @@ public class AsyncStopwatch(Action<TimeSpan> tickHandler, int intervalMillisecon
     /// </summary>
     public void Stop()
     {
-        CancelAndDisposeToken();
-
         _stopwatch.Stop();
+        CancelAndDisposeToken();
         IsRunning = false;
     }
 

--- a/PhaseShift.Core/AsyncStopwatch.cs
+++ b/PhaseShift.Core/AsyncStopwatch.cs
@@ -1,0 +1,88 @@
+﻿using System.Diagnostics;
+
+namespace PhaseShift.Core;
+
+/// <summary>
+/// Represents an asynchronous stopwatch that executes a specified asynchronous callback at regular intervals.
+/// </summary>
+/// <param name="tickHandler">The asynchronous callback to be executed at each interval.</param>
+/// <param name="intervalMilliseconds">The interval in milliseconds at which the callback is executed. Default is 10 milliseconds.</param>
+public class AsyncStopwatch(Action<TimeSpan> tickHandler, int intervalMilliseconds = 10)
+{
+    private readonly Action<TimeSpan> _tickHandler = tickHandler;
+    private readonly int _intervalMilliseconds = intervalMilliseconds;
+    private readonly Stopwatch _stopwatch = new();
+    private CancellationTokenSource? _cancellationTokenSource;
+
+    public TimeSpan ElapsedTime => _stopwatch.Elapsed;
+    public bool IsRunning { get; private set; }
+
+    /// <summary>
+    /// Resets the stopwatch and invokes the callback with the reset elapsed time.
+    /// </summary>
+    public void Reset()
+    {
+        CancelAndDisposeToken();
+
+        _stopwatch.Reset();
+        _tickHandler(_stopwatch.Elapsed);
+
+        IsRunning = false;
+    }
+
+    /// <summary>
+    /// Starts the stopwatch and begins executing the callback at the specified intervals.
+    /// </summary>
+    public void Start()
+    {
+        if (IsRunning)
+        {
+            return;
+        }
+
+        _cancellationTokenSource = new CancellationTokenSource();
+
+        IsRunning = true;
+        Task.Run(() => StartAsync(_cancellationTokenSource.Token)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Stops the stopwatch and cancels the execution of the callback.
+    /// </summary>
+    public void Stop()
+    {
+        CancelAndDisposeToken();
+
+        _stopwatch.Stop();
+        IsRunning = false;
+    }
+
+    private void CancelAndDisposeToken()
+    {
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+    }
+
+    private async Task StartAsync(CancellationToken cancelToken)
+    {
+        _stopwatch.Start();
+
+        while (!cancelToken.IsCancellationRequested)
+        {
+            // Don't await the task to prevent the stopwatch from being stopped
+            // granted, the handler should execute faster than the tick interval!
+
+            Task.Run(() => _tickHandler(_stopwatch.Elapsed), CancellationToken.None).ConfigureAwait(false);
+
+            try
+            {
+                await Task.Delay(_intervalMilliseconds, cancelToken).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                // Stopwatch was stopped, do nothing
+            }
+        }
+    }
+}

--- a/PhaseShift.Core/PhaseShift.Core.csproj
+++ b/PhaseShift.Core/PhaseShift.Core.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/PhaseShift.UI.Tests/Common/TimeSpanConverterTests.cs
+++ b/PhaseShift.UI.Tests/Common/TimeSpanConverterTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Globalization;
+using System.Windows;
+
+using NUnit.Framework;
+
+using PhaseShift.UI.Common;
+
+namespace PhaseShift.UI.Tests.Common;
+
+[TestFixture]
+internal class TimeSpanConverterTests
+{
+    private TimeSpanConverter? _converter;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _converter = new TimeSpanConverter();
+    }
+
+    [Test]
+    public void Convert_ValidTimeSpan_ReturnsFormattedString()
+    {
+        var timeSpan = new TimeSpan(1, 2, 3, 4);
+        var result = _converter!.Convert(timeSpan, typeof(string), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo("1d 02:03:04"));
+    }
+
+    [Test]
+    public void Convert_InvalidValue_ReturnsUnsetValue()
+    {
+        var result = _converter!.Convert("invalid", typeof(string), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(DependencyProperty.UnsetValue));
+    }
+
+    [Test]
+    public void ConvertBack_ValidString_ReturnsTimeSpan()
+    {
+        var timeSpanString = "02:03:04";
+        var result = _converter!.ConvertBack(timeSpanString, typeof(TimeSpan), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(new TimeSpan(2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertBack_InvalidString_ReturnsUnsetValue()
+    {
+        var result = _converter!.ConvertBack("invalid", typeof(TimeSpan), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(DependencyProperty.UnsetValue));
+    }
+}

--- a/PhaseShift.UI.Tests/Mocks/MockDispatcher.cs
+++ b/PhaseShift.UI.Tests/Mocks/MockDispatcher.cs
@@ -1,0 +1,16 @@
+﻿using PhaseShift.UI.Common;
+
+namespace PhaseShift.UI.Tests.Mocks;
+internal class MockDispatcher : IDispatcher
+{
+    public void Invoke(Action action)
+    {
+        action();
+    }
+
+    public Task InvokeAsync(Action action)
+    {
+        action();
+        return Task.CompletedTask;
+    }
+}

--- a/PhaseShift.UI.Tests/Mocks/MockDispatcher.cs
+++ b/PhaseShift.UI.Tests/Mocks/MockDispatcher.cs
@@ -1,7 +1,7 @@
 ﻿using PhaseShift.UI.Common;
 
 namespace PhaseShift.UI.Tests.Mocks;
-internal class MockDispatcher : IDispatcher
+public class MockDispatcher : IDispatcher
 {
     public void Invoke(Action action)
     {

--- a/PhaseShift.UI.Tests/PhaseShift.UI.Tests.csproj
+++ b/PhaseShift.UI.Tests/PhaseShift.UI.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PhaseShift.UI\PhaseShift.UI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PhaseShift.UI.Tests/StopwatchFeature/StopwatchVmTests.cs
+++ b/PhaseShift.UI.Tests/StopwatchFeature/StopwatchVmTests.cs
@@ -95,20 +95,4 @@ internal class StopwatchVmTests
 
         Assert.That(_stopwatchVm.ElapsedTime, Is.EqualTo(TimeSpan.Zero));
     }
-
-    [Test]
-    public async Task StopwatchVm_ShouldHaveAcceptableAccuracy()
-    {
-        // Arrange
-        var acceptableDeviation = TimeSpan.FromMilliseconds(1000); // deviation <= 3.6 s per hour
-        var expectedElapsedTime = TimeSpan.FromMilliseconds(10_000);
-
-        // Act
-        _stopwatchVm!.StartStopwatchCommand.Execute(null);
-        await Task.Delay(expectedElapsedTime);
-        _stopwatchVm.PauseStopwatchCommand.Execute(null);
-
-        // Assert
-        Assert.That(_stopwatchVm.ElapsedTime, Is.EqualTo(expectedElapsedTime).Within(acceptableDeviation));
-    }
 }

--- a/PhaseShift.UI.Tests/StopwatchFeature/StopwatchVmTests.cs
+++ b/PhaseShift.UI.Tests/StopwatchFeature/StopwatchVmTests.cs
@@ -1,0 +1,114 @@
+﻿using NUnit.Framework;
+
+using PhaseShift.UI.Common;
+using PhaseShift.UI.StopwatchFeature;
+using PhaseShift.UI.Tests.Mocks;
+
+namespace PhaseShift.UI.Tests.StopwatchFeature;
+
+[TestFixture]
+internal class StopwatchVmTests
+{
+    private StopwatchVm? _stopwatchVm;
+    private IDispatcher? _mockDispatcher;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockDispatcher = new MockDispatcher();
+        _stopwatchVm = new StopwatchVm(_mockDispatcher);
+    }
+
+    [Test]
+    public void Constructor_InitializesElapsedTimeToZero()
+    {
+        Assert.That(_stopwatchVm!.ElapsedTime, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void Constructor_InitializesIsRunningToFalse()
+    {
+        Assert.That(_stopwatchVm!.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void StartStopwatch_SetsIsRunningToTrue()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        var isRunningAfterStarting = _stopwatchVm.IsRunning;
+
+        Assert.That(isRunningAfterStarting, Is.True);
+    }
+
+    [Test]
+    public void StartStopwatch_CanExecuteIsFalse_AfterStartingStopwatch()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        var canStartAfterStarting = _stopwatchVm.StartStopwatchCommand.CanExecute(null);
+
+        Assert.That(canStartAfterStarting, Is.False);
+    }
+
+    [Test]
+    public async Task StartStopwatch_IncreasesElapsedTime()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        await Task.Delay(1000); // Allow some time for the async handler to be invoked
+
+        Assert.That(_stopwatchVm.ElapsedTime, Is.GreaterThan(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void PauseStopwatch_SetsIsRunningToFalse()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        _stopwatchVm.PauseStopwatchCommand.Execute(null);
+        Assert.That(_stopwatchVm.IsRunning, Is.False);
+    }
+
+    [Test]
+    public async Task PauseStopwatch_DoesNotSetElapsedTimeToZero()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+
+        await Task.Delay(1000); // Allow some time for the async handler to be invoked
+        _stopwatchVm.PauseStopwatchCommand.Execute(null);
+
+        Assert.That(_stopwatchVm.ElapsedTime, Is.Not.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void ResetStopwatch_SetsIsRunningToFalse()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        _stopwatchVm.ResetStopwatchCommand.Execute(null);
+
+        Assert.That(_stopwatchVm.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void ResetStopwatch_SetsElapsedTimeToZero()
+    {
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        Task.Delay(1000).Wait(); // Allow some time to pass
+        _stopwatchVm.ResetStopwatchCommand.Execute(null);
+
+        Assert.That(_stopwatchVm.ElapsedTime, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public async Task StopwatchVm_ShouldHaveAcceptableAccuracy()
+    {
+        // Arrange
+        var acceptableDeviation = TimeSpan.FromMilliseconds(1000); // deviation <= 3.6 s per hour
+        var expectedElapsedTime = TimeSpan.FromMilliseconds(10_000);
+
+        // Act
+        _stopwatchVm!.StartStopwatchCommand.Execute(null);
+        await Task.Delay(expectedElapsedTime);
+        _stopwatchVm.PauseStopwatchCommand.Execute(null);
+
+        // Assert
+        Assert.That(_stopwatchVm.ElapsedTime, Is.EqualTo(expectedElapsedTime).Within(acceptableDeviation));
+    }
+}

--- a/PhaseShift.UI/App.xaml
+++ b/PhaseShift.UI/App.xaml
@@ -1,0 +1,118 @@
+﻿<Application x:Class="PhaseShift.UI.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:PhaseShift.UI"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:common="clr-namespace:PhaseShift.UI.Common"
+             StartupUri="MainWindow.xaml">
+
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <materialDesign:BundledTheme BaseTheme="Inherit"
+                                             ColorAdjustment="{materialDesign:ColorAdjustment}"
+                                             PrimaryColor="DeepPurple"
+                                             SecondaryColor="Lime" />
+
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <common:TimeSpanConverter x:Key="TimeSpanConverter" />
+
+            <!--Timer Button Styles-->
+            <Style x:Key="TimerButtonPrimaryBase"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource MaterialDesignRaisedButton}">
+
+                <Setter Property="Margin"
+                        Value="5" />
+
+                <Setter Property="Padding"
+                        Value="0" />
+            </Style>
+
+            <Style x:Key="TimerButtonSecondaryBase"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource MaterialDesignFlatButton}">
+
+                <Setter Property="Margin"
+                        Value="5" />
+
+                <Setter Property="Padding"
+                        Value="0" />
+            </Style>
+
+            <Style x:Key="StartTimerPrimaryButton"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource TimerButtonPrimaryBase}">
+
+                <Setter Property="Visibility"
+                        Value="Visible" />
+
+                <Style.Triggers>
+
+                    <DataTrigger Binding="{Binding IsRunning}"
+                                 Value="True">
+
+                        <Setter Property="Visibility"
+                                Value="Collapsed" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="StartTimerSecondaryButton"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource TimerButtonSecondaryBase}">
+
+                <Setter Property="Visibility"
+                        Value="Visible" />
+
+                <Style.Triggers>
+
+                    <DataTrigger Binding="{Binding IsRunning}"
+                                 Value="True">
+
+                        <Setter Property="Visibility"
+                                Value="Collapsed" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="StopTimerPrimaryButton"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource TimerButtonPrimaryBase}">
+
+                <Setter Property="Visibility"
+                        Value="Visible" />
+
+                <Style.Triggers>
+
+                    <DataTrigger Binding="{Binding IsRunning}"
+                                 Value="False">
+
+                        <Setter Property="Visibility"
+                                Value="Collapsed" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="StopTimerSecondaryButton"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource TimerButtonSecondaryBase}">
+
+                <Setter Property="Visibility"
+                        Value="Visible" />
+
+                <Style.Triggers>
+
+                    <DataTrigger Binding="{Binding IsRunning}"
+                                 Value="False">
+
+                        <Setter Property="Visibility"
+                                Value="Collapsed" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/PhaseShift.UI/App.xaml.cs
+++ b/PhaseShift.UI/App.xaml.cs
@@ -1,0 +1,9 @@
+﻿using System.Windows;
+
+namespace PhaseShift.UI;
+/// <summary>
+/// Interaction logic for App.xaml
+/// </summary>
+public partial class App : Application
+{
+}

--- a/PhaseShift.UI/AssemblyInfo.cs
+++ b/PhaseShift.UI/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/PhaseShift.UI/Common/Dispatcher.cs
+++ b/PhaseShift.UI/Common/Dispatcher.cs
@@ -1,0 +1,33 @@
+﻿using System.Windows.Threading;
+
+namespace PhaseShift.UI.Common;
+
+/// <summary>
+/// Provides an abstraction for dispatching actions on the UI thread.
+/// Meant to be used in view models to allow easier unit testing.
+/// </summary>
+public interface IDispatcher
+{
+    Task InvokeAsync(Action action);
+    void Invoke(Action action);
+}
+
+/// <summary>
+/// Implementation of <see cref="IDispatcher"/> as a wrapper around <see cref="Dispatcher"/> for WPF.
+/// </summary>
+public class WpfDispatcher(Dispatcher dispatcher) : IDispatcher
+{
+    private readonly Dispatcher _dispatcher = dispatcher;
+
+    /// <inheritdoc cref="Dispatcher.InvokeAsync(Action)"/>
+    public Task InvokeAsync(Action action)
+    {
+        return _dispatcher.InvokeAsync(action).Task;
+    }
+
+    /// <inheritdoc cref="Dispatcher.Invoke(Action)"/>
+    public void Invoke(Action action)
+    {
+        _dispatcher.Invoke(action);
+    }
+}

--- a/PhaseShift.UI/Common/DispatcherWrapper.cs
+++ b/PhaseShift.UI/Common/DispatcherWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Threading;
+﻿using System.Windows;
+using System.Windows.Threading;
 
 namespace PhaseShift.UI.Common;
 
@@ -15,9 +16,11 @@ public interface IDispatcher
 /// <summary>
 /// Implementation of <see cref="IDispatcher"/> as a wrapper around <see cref="Dispatcher"/> for WPF.
 /// </summary>
-public class WpfDispatcher(Dispatcher dispatcher) : IDispatcher
+public class DispatcherWrapper(Dispatcher dispatcher) : IDispatcher
 {
     private readonly Dispatcher _dispatcher = dispatcher;
+
+    public DispatcherWrapper() : this(Application.Current.Dispatcher) { }
 
     /// <inheritdoc cref="Dispatcher.InvokeAsync(Action)"/>
     public Task InvokeAsync(Action action)

--- a/PhaseShift.UI/Common/Icons/StopwatchIcon.xaml
+++ b/PhaseShift.UI/Common/Icons/StopwatchIcon.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="PhaseShift.UI.Common.Icons.StopwatchIcon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:PhaseShift.UI.Common.Icons"
+             xmlns:materialIcons="clr-namespace:Material.Icons.WPF;assembly=Material.Icons.WPF"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d"
+             d:DesignHeight="450"
+             d:DesignWidth="800">
+
+    <Viewbox>
+        <materialIcons:MaterialIcon Kind="Stopwatch" />
+    </Viewbox>
+</UserControl>

--- a/PhaseShift.UI/Common/Icons/StopwatchIcon.xaml.cs
+++ b/PhaseShift.UI/Common/Icons/StopwatchIcon.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows.Controls;
+
+namespace PhaseShift.UI.Common.Icons;
+/// <summary>
+/// Interaction logic for StopwatchIcon.xaml
+/// </summary>
+public partial class StopwatchIcon : UserControl
+{
+    public StopwatchIcon()
+    {
+        InitializeComponent();
+    }
+}

--- a/PhaseShift.UI/Common/PageViewModel.cs
+++ b/PhaseShift.UI/Common/PageViewModel.cs
@@ -1,0 +1,11 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PhaseShift.UI.Common;
+
+/// <summary>
+/// Represents a view model for a page in the main window.
+/// </summary>
+internal abstract class PageViewModel : ObservableObject
+{
+    public abstract string Title { get; }
+}

--- a/PhaseShift.UI/Common/TimeSpanConverter.cs
+++ b/PhaseShift.UI/Common/TimeSpanConverter.cs
@@ -1,0 +1,50 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+using System.Windows;
+
+namespace PhaseShift.UI.Common;
+
+/// <summary>
+/// A converter that converts <see cref="TimeSpan"/> to string and vice versa.
+/// Example input: <c>new TimeSpan(1, 2, 3, 4)</c> will be converted to <c>"1d 02:03:04"</c>.
+/// </summary>
+internal class TimeSpanConverter : IValueConverter
+{
+    private const string DefaultTimeFormat = @"hh\:mm\:ss";
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo? culture)
+    {
+        if (value is not TimeSpan timeSpan)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        var format = parameter as string ?? DefaultTimeFormat;
+
+        try
+        {
+            var timeSpanStr = timeSpan.ToString(format, culture);
+            if (timeSpan.Days > 0)
+            {
+                timeSpanStr = $"{timeSpan.Days}d {timeSpanStr}";
+            }
+
+            return timeSpanStr;
+        }
+        catch (Exception)
+        {
+            return timeSpan.ToString(DefaultTimeFormat, culture);
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo? culture)
+    {
+        if (value is not string timeSpanString
+            || !TimeSpan.TryParse(timeSpanString, out TimeSpan timeSpan))
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        return timeSpan;
+    }
+}

--- a/PhaseShift.UI/MainWindow.xaml
+++ b/PhaseShift.UI/MainWindow.xaml
@@ -1,0 +1,82 @@
+﻿<Window x:Class="PhaseShift.UI.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:PhaseShift.UI"
+        xmlns:stopwatch="clr-namespace:PhaseShift.UI.StopwatchFeature"
+        xmlns:common="clr-namespace:PhaseShift.UI.Common"
+        xmlns:featureIcons="clr-namespace:PhaseShift.UI.Common.Icons"
+        xmlns:materialIcons="clr-namespace:Material.Icons.WPF;assembly=Material.Icons.WPF"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        mc:Ignorable="d"
+        MinHeight="500"
+        Height="500"
+        MinWidth="500"
+        Width="500"
+        Style="{StaticResource MaterialDesignWindow}">
+
+    <Window.DataContext>
+        <local:MainWindowVm />
+    </Window.DataContext>
+
+    <Window.Resources>
+        <Style TargetType="{x:Type Button}"
+               BasedOn="{StaticResource MaterialDesignFlatButton}">
+
+            <Setter Property="Margin"
+                    Value="0 15" />
+        </Style>
+
+        <DataTemplate DataType="{x:Type stopwatch:StopwatchVm}">
+            <stopwatch:StopwatchCtrl />
+        </DataTemplate>
+    </Window.Resources>
+
+    <Grid>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <!--Navigation Menu-->
+        <Border Grid.RowSpan="2"
+                Grid.Column="0"
+                Background="{StaticResource MaterialDesignDarkSeparatorBackground}"
+                Padding="5">
+
+            <StackPanel Orientation="Vertical"
+                        HorizontalAlignment="Center">
+
+                <Button Command="{Binding ShowStopwatchCommand}"
+                        ToolTip="Stopwatch">
+
+                    <featureIcons:StopwatchIcon />
+                </Button>
+            </StackPanel>
+        </Border>
+
+        <!--Title-->
+        <TextBlock Grid.Row="0"
+                   Grid.Column="1"
+                   Margin="0 15 15 0"
+                   HorizontalAlignment="Center"
+                   Text="{Binding CurrentViewModel.Title}"
+                   Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
+
+        <!--Content-->
+        <ContentControl Grid.Row="1"
+                        Grid.Column="1"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        Content="{Binding CurrentViewModel}"
+                        Margin="0 0 15 15" />
+    </Grid>
+</Window>

--- a/PhaseShift.UI/MainWindow.xaml.cs
+++ b/PhaseShift.UI/MainWindow.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows;
+
+namespace PhaseShift.UI;
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/PhaseShift.UI/MainWindowVm.cs
+++ b/PhaseShift.UI/MainWindowVm.cs
@@ -15,7 +15,7 @@ internal partial class MainWindowVm : ObservableObject
     [ObservableProperty]
     private PageViewModel _currentViewModel;
 
-    public MainWindowVm() : this(new WpfDispatcher(Application.Current.Dispatcher)) { }
+    public MainWindowVm() : this(new DispatcherWrapper(Application.Current.Dispatcher)) { }
 
     public MainWindowVm(IDispatcher dispatcher)
     {

--- a/PhaseShift.UI/MainWindowVm.cs
+++ b/PhaseShift.UI/MainWindowVm.cs
@@ -1,0 +1,37 @@
+﻿using System.Windows;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+using PhaseShift.UI.Common;
+using PhaseShift.UI.StopwatchFeature;
+
+namespace PhaseShift.UI;
+
+internal partial class MainWindowVm : ObservableObject
+{
+    private readonly Dictionary<Type, PageViewModel> _viewModels;
+
+    [ObservableProperty]
+    private PageViewModel _currentViewModel;
+
+    public MainWindowVm() : this(new WpfDispatcher(Application.Current.Dispatcher)) { }
+
+    public MainWindowVm(IDispatcher dispatcher)
+    {
+        var stopwatchVm = new StopwatchVm(dispatcher);
+
+        _viewModels = new Dictionary<Type, PageViewModel>
+        {
+            { typeof(StopwatchVm), stopwatchVm },
+        };
+
+        CurrentViewModel = _viewModels[typeof(StopwatchVm)];
+    }
+
+    [RelayCommand]
+    public void ShowStopwatch()
+    {
+        CurrentViewModel = _viewModels[typeof(StopwatchVm)];
+    }
+}

--- a/PhaseShift.UI/PhaseShift.UI.csproj
+++ b/PhaseShift.UI/PhaseShift.UI.csproj
@@ -22,5 +22,8 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 			<_Parameter1>PhaseShift.UI.Tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>PhaseShift.AccuracyTestTool</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 </Project>

--- a/PhaseShift.UI/PhaseShift.UI.csproj
+++ b/PhaseShift.UI/PhaseShift.UI.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Material.Icons.WPF" Version="2.1.10" />
+    <PackageReference Include="MaterialDesignThemes" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PhaseShift.Core\PhaseShift.Core.csproj" />
+  </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>PhaseShift.UI.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+</Project>

--- a/PhaseShift.UI/StopwatchFeature/StopwatchCtrl.xaml
+++ b/PhaseShift.UI/StopwatchFeature/StopwatchCtrl.xaml
@@ -1,0 +1,75 @@
+﻿<UserControl x:Class="PhaseShift.UI.StopwatchFeature.StopwatchCtrl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:PhaseShift.UI.StopwatchFeature"
+             xmlns:materialIcons="clr-namespace:Material.Icons.WPF;assembly=Material.Icons.WPF"
+             mc:Ignorable="d"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             d:Background="White"
+             d:DataContext="{d:DesignInstance local:StopwatchVm, IsDesignTimeCreatable=True}">
+
+    <UserControl.Resources>
+        <Style TargetType="{x:Type ProgressBar}"
+               BasedOn="{StaticResource MaterialDesignCircularProgressBar}">
+
+            <Setter Property="Margin"
+                    Value="15" />
+
+            <Setter Property="Width"
+                    Value="330" />
+
+            <Setter Property="Height"
+                    Value="330" />
+
+            <Setter Property="Minimum"
+                    Value="0" />
+
+            <Setter Property="Maximum"
+                    Value="1" />
+
+            <Setter Property="HorizontalAlignment"
+                    Value="Center" />
+
+            <Setter Property="VerticalAlignment"
+                    Value="Center" />
+        </Style>
+    </UserControl.Resources>
+
+    <StackPanel Margin="15"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+
+        <TextBlock FontSize="48"
+                   HorizontalAlignment="Center"
+                   Text="{Binding ElapsedTime, Converter={StaticResource TimeSpanConverter}, ConverterParameter='hh\\:mm\\:ss\\.fff'}" />
+
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Center"
+                    Margin="10">
+
+            <Button Style="{StaticResource StartTimerSecondaryButton}"
+                    Command="{Binding StartStopwatchCommand}"
+                    ToolTip="Start Stopwatch">
+
+                <materialIcons:MaterialIcon Kind="Play" />
+            </Button>
+
+            <Button Style="{StaticResource StopTimerSecondaryButton}"
+                    Command="{Binding PauseStopwatchCommand}"
+                    ToolTip="Stop Stopwatch">
+
+                <materialIcons:MaterialIcon Kind="Pause" />
+            </Button>
+
+            <Button Style="{StaticResource TimerButtonSecondaryBase}"
+                    Command="{Binding ResetStopwatchCommand}"
+                    ToolTip="Reset Stopwatch">
+
+                <materialIcons:MaterialIcon Kind="Restore" />
+            </Button>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/PhaseShift.UI/StopwatchFeature/StopwatchCtrl.xaml.cs
+++ b/PhaseShift.UI/StopwatchFeature/StopwatchCtrl.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Controls;
+
+namespace PhaseShift.UI.StopwatchFeature;
+
+/// <summary>
+/// Interaction logic for StopwatchCtrl.xaml
+/// </summary>
+public partial class StopwatchCtrl : UserControl
+{
+    public StopwatchCtrl()
+    {
+        InitializeComponent();
+    }
+}

--- a/PhaseShift.UI/StopwatchFeature/StopwatchVm.cs
+++ b/PhaseShift.UI/StopwatchFeature/StopwatchVm.cs
@@ -1,0 +1,60 @@
+﻿using System.Windows;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+using PhaseShift.Core;
+using PhaseShift.UI.Common;
+
+namespace PhaseShift.UI.StopwatchFeature;
+
+internal partial class StopwatchVm : PageViewModel
+{
+    public override string Title => "Stopwatch";
+
+    private readonly AsyncStopwatch _timer;
+    private readonly IDispatcher _dispatcher;
+
+    [ObservableProperty]
+    private TimeSpan elapsedTime = TimeSpan.Zero;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(StartStopwatchCommand))]
+    private bool isRunning = false;
+
+    public StopwatchVm() : this(new WpfDispatcher(Application.Current.Dispatcher)) { }
+
+    public StopwatchVm(IDispatcher dispatcher)
+    {
+        _timer = new AsyncStopwatch(UpdateElapsedTime);
+        _dispatcher = dispatcher;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanStartStopwatch))]
+    private void StartStopwatch()
+    {
+        IsRunning = true;
+        _timer.Start();
+    }
+
+    private bool CanStartStopwatch() => !IsRunning;
+
+    private void UpdateElapsedTime(TimeSpan span)
+    {
+        _dispatcher.Invoke(() => ElapsedTime = span);
+    }
+
+    [RelayCommand]
+    private void PauseStopwatch()
+    {
+        _timer.Stop();
+        IsRunning = false;
+    }
+
+    [RelayCommand]
+    private void ResetStopwatch()
+    {
+        _timer.Reset();
+        IsRunning = false;
+    }
+}

--- a/PhaseShift.UI/StopwatchFeature/StopwatchVm.cs
+++ b/PhaseShift.UI/StopwatchFeature/StopwatchVm.cs
@@ -22,7 +22,7 @@ internal partial class StopwatchVm : PageViewModel
     [NotifyCanExecuteChangedFor(nameof(StartStopwatchCommand))]
     private bool isRunning = false;
 
-    public StopwatchVm() : this(new WpfDispatcher(Application.Current.Dispatcher)) { }
+    public StopwatchVm() : this(new DispatcherWrapper(Application.Current.Dispatcher)) { }
 
     public StopwatchVm(IDispatcher dispatcher)
     {

--- a/PhaseShift.sln
+++ b/PhaseShift.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35728.132
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.Core", "PhaseShift.Core\PhaseShift.Core.csproj", "{D46C0B17-DEA3-421D-A683-7918F813D482}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.Core.Tests", "PhaseShift.Core.Tests\PhaseShift.Core.Tests.csproj", "{3FA1576E-0E5F-4325-AC14-14E9446B803A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.UI", "PhaseShift.UI\PhaseShift.UI.csproj", "{BA66221F-C465-430B-A408-2552521596AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.UI.Tests", "PhaseShift.UI.Tests\PhaseShift.UI.Tests.csproj", "{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D46C0B17-DEA3-421D-A683-7918F813D482}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D46C0B17-DEA3-421D-A683-7918F813D482}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D46C0B17-DEA3-421D-A683-7918F813D482}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D46C0B17-DEA3-421D-A683-7918F813D482}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FA1576E-0E5F-4325-AC14-14E9446B803A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FA1576E-0E5F-4325-AC14-14E9446B803A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FA1576E-0E5F-4325-AC14-14E9446B803A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FA1576E-0E5F-4325-AC14-14E9446B803A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA66221F-C465-430B-A408-2552521596AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA66221F-C465-430B-A408-2552521596AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA66221F-C465-430B-A408-2552521596AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA66221F-C465-430B-A408-2552521596AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/PhaseShift.sln
+++ b/PhaseShift.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.UI", "PhaseShift
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.UI.Tests", "PhaseShift.UI.Tests\PhaseShift.UI.Tests.csproj", "{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhaseShift.AccuracyTestTool", "PhaseShift.AccuracyTestTool\PhaseShift.AccuracyTestTool.csproj", "{956534D1-8701-4E6A-A1CD-9D3E9ED343F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33311E4C-EC81-4C7E-AE1A-CA0BCE77CCCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{956534D1-8701-4E6A-A1CD-9D3E9ED343F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{956534D1-8701-4E6A-A1CD-9D3E9ED343F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{956534D1-8701-4E6A-A1CD-9D3E9ED343F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{956534D1-8701-4E6A-A1CD-9D3E9ED343F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I have implemented a Stopwatch feature that allows the user to measure the time elapsed since starting the stopwatch. The stopwatch can be paused and restarted or reset to its initial state.

The UI uses the Community MVVM kit and MaterialDesign for WPF for the visuals. Internally, the stopwatch is represented by an `AsyncStopwatch`. This class executes a tick loop on a background thread. At the beginning of a tick, a callback is executed on yet another background thread but not awaited so as not to delay the ticks. After dispatching the callback, the loop is delayed for the tick interval. This `AsyncStopwatch` is then used in the view model for the stopwatch feature, which updates its `ElapsedTime` property via that tick callback. The corresponding view then binds to this property to show the elapsed time in a display.

The `AsyncStopwatch` can be stopped, which cancels the tick loop, breaking it. The view model exposes the methods for starting and stopping via `RelayCommands` that are then bound to in the view.

The main view model already implements a dictionary that maps view model types to their instances and an observable property for the current view model that the main window then binds its `ContentControl` to. Currently, only the stopwatch view model is regestered. The main window maps the view models to the correct views via data templates.

Unit tests for the relevant types (complicated enough) are included.