### PR TITLE
Fix two issues at the end of a pomodoro session.

### DIFF
--- a/PhaseShift.Core/PomodoroTimer.cs
+++ b/PhaseShift.Core/PomodoroTimer.cs
@@ -76,6 +76,12 @@ public class PomodoroTimer
 
     public void ResetCurrentPhase()
     {
+        if (IsCompleted)
+        {
+            _elapsedTimeInPreviousPhases -= _currentTimer.Duration;
+            --CompletedWorkUnits;
+        }
+
         _currentTimer.Reset();
     }
 

--- a/PhaseShift.UI/PomodoroFeature/PomodoroTimerVm.cs
+++ b/PhaseShift.UI/PomodoroFeature/PomodoroTimerVm.cs
@@ -111,6 +111,7 @@ internal partial class PomodoroTimerVm : PageViewModel
     {
         WorkUnitsCompleted = _pomodoroTimer.CompletedWorkUnits;
         CurrentPhase = _pomodoroTimer.CurrentPhase;
+        IsRunning = _pomodoroTimer.IsRunning;
     }
 
     private void NotifyPomodoroPhaseCompleted()
@@ -125,6 +126,7 @@ internal partial class PomodoroTimerVm : PageViewModel
     {
         _pomodoroTimer.ResetCurrentPhase();
         IsRunning = _pomodoroTimer.IsRunning;
+        WorkUnitsCompleted = _pomodoroTimer.CompletedWorkUnits;
 
         UpdateOnTick();
     }
@@ -168,6 +170,7 @@ internal partial class PomodoroTimerVm : PageViewModel
         ElapsedTimeInSession = _pomodoroTimer.ElapsedTimeInSession;
         RemainingTimeInSession = _pomodoroTimer.RemainingTimeInSession;
         ProgressInCurrentPhase = _pomodoroTimer.ProgressInCurrentPhase;
+        IsRunning = _pomodoroTimer.IsRunning;
     }
 
     public void UpdateSettings(PomodoroSettings newSettings)


### PR DESCRIPTION
- When the pomodoro session completed, the timer is still shown as running. This is now updated in the session completed handler.
- When resetting the current phase after session completion, the last work phase is not reset and when starting, a new session starts. When resetting the last work phase, the number of completed work units is now decremented as is necessary and also the work duration is subtracted from the time elpased in completed phases.
